### PR TITLE
fix: gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: Set remote url
-        run: git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/bcnmy/sdk
+        run: git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/bcnmy/sdk.git
 
       - name: Run the tests
         run: bun run docs:deploy


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GitHub Actions workflow for documentation deployment. It changes the remote URL for the origin repository and fixes the command to run the tests.

### Detailed summary
- Updated remote URL for origin repository
- Changed the command to run the tests from "bun run docs:deploy" to "git remote set-url origin ..."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->