### PR TITLE
chore: add permission

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -12,6 +12,7 @@ jobs:
     name: size report
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: write-all
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new permission setting to the GitHub Actions workflow for generating size reports.

### Detailed summary
- Added `permissions: write-all` setting to the GitHub Actions workflow for size reports.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->