### PR TITLE
fix: fixed issue with maxFeePerGas and maxPriorityFeePerGas being 0

### DIFF
--- a/src/accounts/actions/sendTransaction.ts
+++ b/src/accounts/actions/sendTransaction.ts
@@ -1,10 +1,9 @@
-import {
-  type Chain,
-  type Client,
-  type Hash,
-  type SendTransactionParameters,
-  type Transport,
-  toHex
+import type {
+  Chain,
+  Client,
+  Hash,
+  SendTransactionParameters,
+  Transport
 } from "viem"
 import type { Prettify } from "viem/chains"
 import { waitForUserOperationReceipt } from "../../bundler/actions/waitForUserOperationReceipt"
@@ -110,8 +109,8 @@ export async function sendTransaction<
   )({
     userOperation: {
       sender: account.address,
-      maxFeePerGas: toHex(maxFeePerGas || 0n),
-      maxPriorityFeePerGas: toHex(maxPriorityFeePerGas || 0n),
+      maxFeePerGas: maxFeePerGas,
+      maxPriorityFeePerGas: maxPriorityFeePerGas,
       callData: callData,
       nonce: nonce ? BigInt(nonce) : undefined
     },

--- a/src/accounts/actions/sendTransactions.ts
+++ b/src/accounts/actions/sendTransactions.ts
@@ -1,12 +1,11 @@
-import {
-  type Address,
-  type Chain,
-  type Client,
-  type Hash,
-  type Hex,
-  type SendTransactionParameters,
-  type Transport,
-  toHex
+import type {
+  Address,
+  Chain,
+  Client,
+  Hash,
+  Hex,
+  SendTransactionParameters,
+  Transport
 } from "viem"
 import type { Prettify } from "viem/chains"
 import { waitForUserOperationReceipt } from "../../bundler/actions/waitForUserOperationReceipt"
@@ -118,8 +117,8 @@ export async function sendTransactions<
   )({
     userOperation: {
       sender: account.address,
-      maxFeePerGas: toHex(maxFeePerGas || 0n),
-      maxPriorityFeePerGas: toHex(maxPriorityFeePerGas || 0n),
+      maxFeePerGas: maxFeePerGas,
+      maxPriorityFeePerGas: maxPriorityFeePerGas,
       callData: callData,
       nonce: nonce ? BigInt(nonce) : undefined
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates `sendTransaction` and `sendTransactions` functions to remove unnecessary `toHex` conversions and import types from "viem".

### Detailed summary
- Removed `toHex` conversions in `sendTransaction` and `sendTransactions`
- Imported types from "viem" in both functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->