### PR TITLE
feat: get address error message

### DIFF
--- a/src/sdk/account/toNexusAccount.ts
+++ b/src/sdk/account/toNexusAccount.ts
@@ -200,9 +200,9 @@ export const toNexusAccount = async (
       if (e.shortMessage?.includes(ERROR_MESSAGES.MISSING_ACCOUNT_CONTRACT)) {
         throw new Error(
           "Failed to compute account address. Possible reasons:\n" +
-          "- The factory contract does not have the function 'computeAccountAddress'\n" +
-          "- The parameters passed to the factory contract function may be invalid\n" +
-          "- The provided factory address is not a contract"
+            "- The factory contract does not have the function 'computeAccountAddress'\n" +
+            "- The parameters passed to the factory contract function may be invalid\n" +
+            "- The provided factory address is not a contract"
         )
       }
       throw e

--- a/src/sdk/account/toNexusAccount.ts
+++ b/src/sdk/account/toNexusAccount.ts
@@ -198,8 +198,14 @@ export const toNexusAccount = async (
       })) as Address
     } catch (e: any) {
       if (e.shortMessage?.includes(ERROR_MESSAGES.MISSING_ACCOUNT_CONTRACT)) {
-        throw new Error(ERROR_MESSAGES.ACCOUNT_NOT_DEPLOYED)
+        throw new Error(
+          "Failed to compute account address. Possible reasons:\n" +
+          "- The factory contract does not have the function 'computeAccountAddress'\n" +
+          "- The parameters passed to the factory contract function may be invalid\n" +
+          "- The provided factory address is not a contract"
+        )
       }
+      throw e
     }
 
     return _accountAddress

--- a/src/sdk/account/utils/Constants.ts
+++ b/src/sdk/account/utils/Constants.ts
@@ -25,7 +25,8 @@ export const ERROR_MESSAGES = {
     'The contract function "computeAccountAddress" returned no data ("0x")',
   INVALID_HEX:
     "Invalid hex, if you are targeting a number, consider using pad() and toHex() from viem: pad(toHex(BigInt(2000))",
-  CONTRACT_NOT_DEPLOYED: "Address is not a contract. Make sure that the contract you are trying to use is deployed.",
+  CONTRACT_NOT_DEPLOYED:
+    "Address is not a contract. Make sure that the contract you are trying to use is deployed.",
   ACCOUNT_NOT_DEPLOYED: "Account has not yet been deployed",
   ACCOUNT_ALREADY_DEPLOYED: "Account already deployed",
   NO_NATIVE_TOKEN_BALANCE_DURING_DEPLOY:

--- a/src/sdk/account/utils/Constants.ts
+++ b/src/sdk/account/utils/Constants.ts
@@ -25,6 +25,7 @@ export const ERROR_MESSAGES = {
     'The contract function "computeAccountAddress" returned no data ("0x")',
   INVALID_HEX:
     "Invalid hex, if you are targeting a number, consider using pad() and toHex() from viem: pad(toHex(BigInt(2000))",
+  CONTRACT_NOT_DEPLOYED: "Address is not a contract. Make sure that the contract you are trying to use is deployed.",
   ACCOUNT_NOT_DEPLOYED: "Account has not yet been deployed",
   ACCOUNT_ALREADY_DEPLOYED: "Account already deployed",
   NO_NATIVE_TOKEN_BALANCE_DURING_DEPLOY:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces new error messages and modifies existing ones to improve clarity regarding account deployment issues and contract interactions.

### Detailed summary
- Added a new error message `CONTRACT_NOT_DEPLOYED` for cases when an address is not a contract.
- Modified the error thrown when an account is not deployed to provide detailed reasons for the failure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->