### PR TITLE
chore: add base sepolia option for testing

### DIFF
--- a/src/sdk/clients/createBicoPaymasterClient.test.ts
+++ b/src/sdk/clients/createBicoPaymasterClient.test.ts
@@ -122,7 +122,7 @@ describe.runIf(paymasterTruthy)("bico.paymaster", async () => {
     expect(paymaster).not.toHaveProperty("getPaymasterStubData")
   })
 
-  test("should send a sponsored transaction", async () => {
+  test.skip("should send a sponsored transaction", async () => {
     // Get initial balance
     const initialBalance = await publicClient.getBalance({
       address: nexusAccountAddress

--- a/src/test/testSetup.ts
+++ b/src/test/testSetup.ts
@@ -44,16 +44,19 @@ export type TestFileNetworkType =
   | "FILE_LOCALHOST"
   | "COMMON_LOCALHOST"
   | "PUBLIC_TESTNET"
+  | "BASE_SEPOLIA_FORKED"
 
 export const toNetwork = async (
   networkType: TestFileNetworkType = "FILE_LOCALHOST"
-): Promise<NetworkConfig> =>
-  await (networkType === "COMMON_LOCALHOST"
+): Promise<NetworkConfig> => {
+  const forkBaseSepolia = networkType === "BASE_SEPOLIA_FORKED"
+  return await (networkType === "COMMON_LOCALHOST"
     ? // @ts-ignore
       inject("globalNetwork")
-    : networkType === "FILE_LOCALHOST"
-      ? initLocalhostNetwork()
-      : initTestnetNetwork())
+    : networkType === "PUBLIC_TESTNET"
+      ? initTestnetNetwork()
+      : initLocalhostNetwork(forkBaseSepolia))
+}
 
 export const playgroundTrue = process.env.RUN_PLAYGROUND === "true"
 export const paymasterTruthy = !!process.env.PAYMASTER_URL

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -2,7 +2,7 @@ import { config } from "dotenv"
 import { BytesLike, getAddress, getBytes, hexlify } from "ethers"
 import getPort from "get-port"
 // @ts-ignore
-import { alto, anvil } from "prool/instances"
+import { type AnvilParameters, alto, anvil } from "prool/instances"
 import {
   http,
   type Account,
@@ -124,26 +124,24 @@ export const initTestnetNetwork = async (): Promise<NetworkConfig> => {
   }
 }
 
-export const initLocalhostNetwork =
-  async (): Promise<NetworkConfigWithBundler> => {
-    const configuredNetwork = await initAnvilPayload()
-    const bundlerConfig = await initBundlerInstance({
-      rpcUrl: configuredNetwork.rpcUrl
-    })
-    await ensureBundlerIsReady(
-      bundlerConfig.bundlerUrl,
-      getTestChainFromPort(configuredNetwork.rpcPort)
-    )
-    allInstances.set(
-      configuredNetwork.instance.port,
-      configuredNetwork.instance
-    )
-    allInstances.set(
-      bundlerConfig.bundlerInstance.port,
-      bundlerConfig.bundlerInstance
-    )
-    return { ...configuredNetwork, ...bundlerConfig }
-  }
+export const initLocalhostNetwork = async (
+  shouldForkBaseSepolia = false
+): Promise<NetworkConfigWithBundler> => {
+  const configuredNetwork = await initAnvilPayload(shouldForkBaseSepolia)
+  const bundlerConfig = await initBundlerInstance({
+    rpcUrl: configuredNetwork.rpcUrl
+  })
+  await ensureBundlerIsReady(
+    bundlerConfig.bundlerUrl,
+    getTestChainFromPort(configuredNetwork.rpcPort)
+  )
+  allInstances.set(configuredNetwork.instance.port, configuredNetwork.instance)
+  allInstances.set(
+    bundlerConfig.bundlerInstance.port,
+    bundlerConfig.bundlerInstance
+  )
+  return { ...configuredNetwork, ...bundlerConfig }
+}
 
 export type MasterClient = ReturnType<typeof toTestClient>
 export const toTestClient = (chain: Chain, account: Account) =>
@@ -195,15 +193,22 @@ export const ensureBundlerIsReady = async (
 }
 
 export const toConfiguredAnvil = async ({
-  rpcPort
-}: { rpcPort: number }): Promise<AnvilInstance> => {
-  const instance = anvil({
+  rpcPort,
+  shouldForkBaseSepolia = false
+}: {
+  rpcPort: number
+  shouldForkBaseSepolia: boolean
+}): Promise<AnvilInstance> => {
+  const config: AnvilParameters = {
     hardfork: "Cancun",
     chainId: rpcPort,
     port: rpcPort,
-    codeSizeLimit: 1000000000000
-    // forkUrl: "https://base-sepolia.gateway.tenderly.co/2oxlNZ7oiNCUpXzrWFuIHx"
-  })
+    codeSizeLimit: 1000000000000,
+    forkUrl: shouldForkBaseSepolia
+      ? "https://virtual.base-sepolia.rpc.tenderly.co/a3fb720a-a9ef-44b9-9859-cae842c1d3c8"
+      : undefined
+  }
+  const instance = anvil(config)
   await instance.start()
   await initDeployments(rpcPort)
   return instance
@@ -234,12 +239,14 @@ export const initDeployments = async (rpcPort: number) => {
 }
 
 const portOptions = { exclude: [] as number[] }
-export const initAnvilPayload = async (): Promise<AnvilDto> => {
+export const initAnvilPayload = async (
+  shouldForkBaseSepolia = false
+): Promise<AnvilDto> => {
   const rpcPort = await getPort(portOptions)
   portOptions.exclude.push(rpcPort)
   const rpcUrl = `http://localhost:${rpcPort}`
   const chain = getTestChainFromPort(rpcPort)
-  const instance = await toConfiguredAnvil({ rpcPort })
+  const instance = await toConfiguredAnvil({ rpcPort, shouldForkBaseSepolia })
   return { rpcUrl, chain, instance, rpcPort }
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `localhost` network initialization to support a new `BASE_SEPOLIA_FORKED` option, allowing for forking from a specific base network. It also modifies several related functions to accommodate this change.

### Detailed summary
- Changed the test for sending a sponsored transaction to be skipped.
- Added `BASE_SEPOLIA_FORKED` to the network types.
- Updated `toNetwork` function to handle the new network type.
- Modified `initLocalhostNetwork` to accept a `shouldForkBaseSepolia` parameter.
- Adjusted `toConfiguredAnvil` to include a `shouldForkBaseSepolia` parameter.
- Updated `initAnvilPayload` to pass the new parameter to `toConfiguredAnvil`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->