### PR TITLE
refactor: remove account param from nexus client

### DIFF
--- a/src/sdk/clients/createBicoBundlerClient.test.ts
+++ b/src/sdk/clients/createBicoBundlerClient.test.ts
@@ -54,17 +54,8 @@ describe("bico.bundler", async () => {
       bicoBundler.getChainId(),
       bicoBundler.getSupportedEntryPoints(),
       bicoBundler.prepareUserOperation({
-        sender: eoaAccount.address,
-        nonce: 0n,
-        data: "0x",
-        signature: "0x",
-        verificationGasLimit: 1n,
-        preVerificationGas: 1n,
-        callData: "0x",
-        callGasLimit: 1n,
-        maxFeePerGas: 1n,
-        maxPriorityFeePerGas: 1n,
-        account: nexusAccount
+        account: nexusAccount,
+        calls: [{ to: eoaAccount.address, data: "0x" }]
       })
     ])
     expect(chainId).toEqual(chain.id)

--- a/src/sdk/clients/createNexusClient.test.ts
+++ b/src/sdk/clients/createNexusClient.test.ts
@@ -10,7 +10,6 @@ import {
   parseEther
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
-import { baseSepolia } from "viem/chains"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
 import { CounterAbi } from "../../test/__contracts/abi"
 import mockAddresses from "../../test/__contracts/mockAddresses"
@@ -63,7 +62,6 @@ describe("nexus.client", async () => {
       transport: http(),
       bundlerTransport: http(bundlerUrl)
     })
-
     nexusAccountAddress = await nexusClient.account.getCounterFactualAddress()
   })
   afterAll(async () => {

--- a/src/sdk/clients/createNexusClient.ts
+++ b/src/sdk/clients/createNexusClient.ts
@@ -90,19 +90,12 @@ export type NexusClient<
 export type NexusClientConfig<
   transport extends Transport = Transport,
   chain extends Chain | undefined = Chain | undefined,
-  account extends SmartAccount | undefined = SmartAccount | undefined,
   client extends Client | undefined = Client | undefined,
   rpcSchema extends RpcSchema | undefined = undefined
 > = Prettify<
   Pick<
-    ClientConfig<transport, chain, account, rpcSchema>,
-    | "account"
-    | "cacheTime"
-    | "chain"
-    | "key"
-    | "name"
-    | "pollingInterval"
-    | "rpcSchema"
+    ClientConfig<transport, chain, SmartAccount, rpcSchema>,
+    "cacheTime" | "chain" | "key" | "name" | "pollingInterval" | "rpcSchema"
   > & {
     /** RPC URL. */
     transport: transport
@@ -130,7 +123,7 @@ export type NexusClientConfig<
           /** Prepares fee properties for the User Operation request. */
           estimateFeesPerGas?:
             | ((parameters: {
-                account: account | SmartAccount
+                account: SmartAccount | undefined
                 bundlerClient: Client
                 userOperation: UserOperationRequest
               }) => Promise<EstimateFeesPerGasReturnType<"eip1559">>)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the handling of `SmartAccount` in the `nexus` client and improving the `prepareUserOperation` method in the `bicoBundler` client by adding support for calls.

### Detailed summary
- Modified `bicoBundler.prepareUserOperation` to include `calls` parameter.
- Changed `account` type in `NexusClientConfig` from `SmartAccount | undefined` to `SmartAccount`.
- Adjusted `estimateFeesPerGas` to accept `SmartAccount | undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->