### PR TITLE
feat: add moduleActivator and cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "typedoc": "^0.25.9",
     "viem": "2.21.6",
     "vitest": "^1.3.1",
-    "yargs": "^17.7.2",
-    "@rhinestone/module-sdk": "^0.1.25"
+    "yargs": "^17.7.2"
   },
   "peerDependencies": {
     "typescript": "^5",

--- a/src/sdk/account/toNexusAccount.ts
+++ b/src/sdk/account/toNexusAccount.ts
@@ -368,7 +368,7 @@ export const toNexusAccount = async (
       const key: string = concat([
         toHex(defaultedKey, { size: 3 }),
         defaultedValidationMode,
-        module.address
+        module.address as Hex
       ])
 
       const accountAddress = await getAddress()
@@ -402,7 +402,7 @@ export const toNexusAccount = async (
 
     const signature = encodePacked(
       ["address", "bytes"],
-      [module.address, tempSignature]
+      [module.address as Hex, tempSignature]
     )
 
     const erc6492Signature = concat([
@@ -498,7 +498,7 @@ export const toNexusAccount = async (
 
     signature = encodePacked(
       ["address", "bytes"],
-      [module.address, signatureData]
+      [module.address as Hex, signatureData]
     )
 
     return signature

--- a/src/sdk/clients/decorators/erc7579/index.ts
+++ b/src/sdk/clients/decorators/erc7579/index.ts
@@ -31,6 +31,7 @@ import {
   type IsModuleInstalledParameters,
   isModuleInstalled
 } from "./isModuleInstalled.js"
+import { moduleActivator } from "./moduleActivator"
 import {
   type SupportsExecutionModeParameters,
   supportsExecutionMode
@@ -113,7 +114,8 @@ export {
   getInstalledExecutors,
   getActiveHook,
   getFallbackBySelector,
-  getPreviousModule
+  getPreviousModule,
+  moduleActivator
 }
 
 export function erc7579Actions() {

--- a/src/sdk/clients/decorators/erc7579/moduleActivator.ts
+++ b/src/sdk/clients/decorators/erc7579/moduleActivator.ts
@@ -1,0 +1,20 @@
+import type { Chain, Client, Transport } from "viem"
+import type { Module } from "../../../modules"
+import type { ModularSmartAccount } from "../../../modules/utils/Types"
+
+export type ModuleActions = Record<string, never>
+
+/**
+ * Creates a decorator function that activates a specific module for a modular smart account client
+ * @param module - The module to be activated on the smart account
+ * @returns An empty object
+ * @remarks This decorator is used to only set the module on the client
+ */
+export function moduleActivator(module: Module) {
+  return <TModularSmartAccount extends ModularSmartAccount | undefined>(
+    client: Client<Transport, Chain | undefined, TModularSmartAccount>
+  ): ModuleActions => {
+    client?.account?.setModule(module)
+    return {} as ModuleActions
+  }
+}

--- a/src/sdk/modules/k1Validator/toK1Validator.ts
+++ b/src/sdk/modules/k1Validator/toK1Validator.ts
@@ -9,8 +9,8 @@ import { sanitizeSignature } from "../utils/Helpers"
 import type { Module, ModuleMeta, ModuleParameters } from "../utils/Types"
 import { toModule } from "../utils/toModule"
 
-export type ToK1ValidatorParameters = ModuleParameters & {
-  address?: Hex
+export type ToK1ValidatorParameters = Omit<ModuleParameters, "address"> & {
+  address?: ModuleParameters["address"]
 }
 
 export type K1ModuleGetInitDataArgs = {

--- a/src/sdk/modules/ownableValidator/toOwnableValidator.executor.test.ts
+++ b/src/sdk/modules/ownableValidator/toOwnableValidator.executor.test.ts
@@ -30,6 +30,7 @@ import {
   type NexusClient,
   createNexusClient
 } from "../../clients/createNexusClient"
+import { moduleActivator } from "../../clients/decorators/erc7579/moduleActivator"
 import { toK1Validator } from "../k1Validator/toK1Validator"
 import type { Module } from "../utils/Types"
 
@@ -72,7 +73,7 @@ describe("modules.ownableExecutor", async () => {
       accountAddress: nexusClient.account.address
     })
 
-    nexusClient.account.setModule(k1Module)
+    nexusClient.extend(moduleActivator(k1Module))
   })
 
   afterAll(async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on refactoring and enhancing the module handling in the codebase, particularly through the introduction of the `moduleActivator` function. It also modifies the `ToK1ValidatorParameters` type to improve type safety.

### Detailed summary
- Updated `ToK1ValidatorParameters` to use `Omit` for better type handling.
- Introduced `moduleActivator` function to activate modules for modular smart accounts.
- Changed usage of `module.address` to `module.address as Hex` for type safety.
- Adjusted imports to include `moduleActivator` where necessary.
- Updated test cases to use `moduleActivator` instead of direct module setting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->