### PR TITLE
feat: add public counterfactual address

### DIFF
--- a/src/test/playground.test.ts
+++ b/src/test/playground.test.ts
@@ -9,6 +9,7 @@ import {
   createWalletClient
 } from "viem"
 import { beforeAll, describe, expect, test } from "vitest"
+import { computeNexusAddress } from "../sdk/account/toNexusAccount"
 import { playgroundTrue } from "../sdk/account/utils/Utils"
 import {
   type NexusClient,
@@ -118,5 +119,18 @@ describe.skipIf(!playgroundTrue)("playground", () => {
     })
     expect(status).toBe("success")
     expect(balanceAfter - balanceBefore).toBe(1n)
+  })
+
+  test("should compute counterfactual address without creating account", async () => {
+    const computedAddress = await computeNexusAddress({
+      chain,
+      transport: http(),
+      signerAddress: eoaAccount.address
+    })
+
+    // Later when we create the actual account, the addresses should match
+    const actualAddress = await nexusClient.account.getCounterFactualAddress()
+    expect(computedAddress).toBe(actualAddress)
+    expect(computedAddress).toMatch(/^0x[a-fA-F0-9]{40}$/)
   })
 })


### PR DESCRIPTION
A method to check the address of the user

To use
```ts
const address = await computeNexusAddress({
  chain: mainnet,
  transport: http(),
  signerAddress: "0x...",
  index: 0n
})
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new function `computeNexusAddress` to compute the counterfactual address for a Nexus account without creating it. It also adds a test to verify that the computed address matches the actual address generated by the Nexus client.

### Detailed summary
- Added the `computeNexusAddress` function in `src/sdk/account/toNexusAccount.ts`.
- The function computes a counterfactual address based on provided parameters.
- Added a test case in `src/test/playground.test.ts` to verify the functionality of `computeNexusAddress`.
- The test checks that the computed address matches the actual address from the Nexus client and validates the address format.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->