### PR TITLE
feat: to signer tests

### DIFF
--- a/src/sdk/account/utils/toSigner.test.ts
+++ b/src/sdk/account/utils/toSigner.test.ts
@@ -1,0 +1,73 @@
+import { JsonRpcProvider } from "ethers"
+import { http, type Address, type Hex, createWalletClient } from "viem"
+import { privateKeyToAccount } from "viem/accounts"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { toNetwork } from "../../../test/testSetup"
+import { type NetworkConfig, killNetwork, pKey } from "../../../test/testUtils"
+import { addressEquals } from "./Utils"
+import { toSigner } from "./toSigner"
+
+const TEST_TYPED_DATA = {
+  primaryType: "Person",
+  domain: {
+    name: "Test Protocol",
+    version: "1",
+    chainId: 1,
+    verifyingContract: "0x0000000000000000000000000000000000000001" as Address
+  },
+  types: {
+    Person: [
+      { name: "name", type: "string" },
+      { name: "wallet", type: "address" }
+    ]
+  },
+  message: {
+    name: "Bob",
+    wallet: "0x0000000000000000000000000000000000000001"
+  }
+} as const
+
+describe("to.signer", () => {
+  let network: NetworkConfig
+
+  beforeAll(async () => {
+    network = await toNetwork()
+  })
+
+  afterAll(async () => {
+    await killNetwork([network?.rpcPort, network?.bundlerPort])
+  })
+
+  it("should work with viem WalletClient", async () => {
+    const account = privateKeyToAccount(pKey as Hex)
+    const client = createWalletClient({
+      account,
+      chain: network.chain,
+      transport: http(network.rpcUrl)
+    })
+
+    const signer = await toSigner({ signer: client })
+
+    expect(addressEquals(signer.address, account.address)).toBe(true)
+
+    // Test message signing
+    const signature = await signer.signMessage({ message: "Hello World" })
+    expect(signature).toBeTruthy()
+    expect(typeof signature).toBe("string")
+
+    // Test typed data signing
+    const typedSignature = await signer.signTypedData(TEST_TYPED_DATA)
+    expect(typedSignature).toBeTruthy()
+    expect(typeof typedSignature).toBe("string")
+  })
+
+  it("should work with viem Account", async () => {
+    const account = privateKeyToAccount(pKey as Hex)
+    const signer = await toSigner({ signer: account })
+
+    expect(signer.address).toBe(account.address)
+
+    const signature = await signer.signMessage({ message: "Hello World" })
+    expect(signature).toBeTruthy()
+  })
+})

--- a/src/sdk/account/utils/toSigner.ts
+++ b/src/sdk/account/utils/toSigner.ts
@@ -21,88 +21,51 @@ import { signTypedData } from "viem/actions"
 import { getAction } from "viem/utils"
 import type { AnyData } from "../../modules/utils/Types"
 
-/**
- * Represents the minimum interface required for a signer implementation.
- * Provides basic signing capabilities for transactions, messages, and typed data.
- */
-export type MinimalSigner = {
-  /** Signs a transaction with the provided arguments */
-  signTransaction: (...args: AnyData[]) => Promise<AnyData>
-  /** Signs a message with the provided arguments */
-  signMessage: (...args: AnyData[]) => Promise<AnyData>
-  /** Signs typed data (EIP-712) with the provided arguments */
-  signTypedData: (...args: AnyData[]) => Promise<AnyData>
-  /** Optional method to retrieve the signer's address */
-  getAddress?: () => Promise<AnyData>
-  /** The signer's address */
-  address: Address | string
-  /** Optional provider instance */
-  provider?: AnyData
-  /** Allows for additional properties */
-  [key: string]: AnyData
-}
-
-/** Represents a local account that can sign transactions and messages */
 export type Signer = LocalAccount
-
-/**
- * Union type of various signer implementations that can be converted to a LocalAccount.
- * Supports EIP-1193 providers, WalletClients, LocalAccounts, Accounts, and MinimalSigners.
- */
 export type UnknownSigner = OneOf<
   | EIP1193Provider
   | WalletClient<Transport, Chain | undefined, Account>
   | LocalAccount
-  | Account
-  | MinimalSigner
 >
 
-/**
- * Converts various signer types into a standardized LocalAccount format.
- * Handles conversion from different wallet implementations including ethers.js wallets,
- * EIP-1193 providers, and existing LocalAccounts.
- *
- * @param signer - The signer to convert, must implement required signing methods
- * @param address - Optional address to use for the account
- * @returns A Promise resolving to a LocalAccount
- *
- * @throws {Error} When signTransaction is called (not supported)
- * @throws {Error} When address is required but not provided
- */
+export type EthersProvider = {
+  getAddress: () => Promise<string>
+  signMessage: (message: AnyData) => Promise<string>
+  signTypedData: (
+    domain: AnyData,
+    types: AnyData,
+    value: AnyData
+  ) => Promise<string>
+}
+
 export async function toSigner({
   signer,
   address
 }: {
-  signer: UnknownSigner & {
-    getAddress: () => Promise<string>
-    signMessage: (message: AnyData) => Promise<string>
-    signTypedData: (
-      domain: AnyData,
-      types: AnyData,
-      value: AnyData
-    ) => Promise<string>
-  }
+  signer: Signer
   address?: Address
 }): Promise<LocalAccount> {
-  // ethers Wallet does not have type property
   if ("provider" in signer) {
+    const ethersProvider = signer as unknown as EthersProvider
     return toAccount({
-      address: getAddress((await signer.getAddress()) as string),
+      address: getAddress((await ethersProvider?.getAddress()) as string),
       async signMessage({ message }): Promise<Hex> {
         if (typeof message === "string") {
-          return (await signer.signMessage(message)) as Hex
+          return (await ethersProvider.signMessage(message)) as Hex
         }
         // For ethers, raw messages need to be converted to Uint8Array
         if (typeof message.raw === "string") {
-          return (await signer.signMessage(hexToBytes(message.raw))) as Hex
+          return (await ethersProvider.signMessage(
+            hexToBytes(message.raw)
+          )) as Hex
         }
-        return (await signer.signMessage(message.raw)) as Hex
+        return (await ethersProvider.signMessage(message.raw)) as Hex
       },
       async signTransaction(_) {
         throw new Error("Not supported")
       },
       async signTypedData(typedData) {
-        return signer.signTypedData(
+        return ethersProvider.signTypedData(
           typedData.domain as AnyData,
           typedData.types as AnyData,
           typedData.message as AnyData
@@ -110,7 +73,8 @@ export async function toSigner({
       }
     })
   }
-  if ("type" in signer && ["local", "dan"].includes(signer.type)) {
+
+  if ("type" in signer && signer.type === "local") {
     return signer as LocalAccount
   }
 
@@ -134,16 +98,22 @@ export async function toSigner({
         )
       }
     }
-    if (!address) throw new Error("address required")
-
+    if (!address) {
+      // For TS to be happy
+      throw new Error("address is required")
+    }
     walletClient = createWalletClient({
       account: address,
-      transport: custom(signer as EIP1193Provider)
+      transport: custom(signer as unknown as EIP1193Provider)
     })
   }
 
   if (!walletClient) {
-    walletClient = signer as WalletClient<Transport, Chain | undefined, Account>
+    walletClient = signer as unknown as WalletClient<
+      Transport,
+      Chain | undefined,
+      Account
+    >
   }
 
   return toAccount({
@@ -156,10 +126,10 @@ export async function toSigner({
         walletClient,
         signTypedData,
         "signTypedData"
-      )(typedData as AnyData)
+      )(typedData as any)
     },
     async signTransaction(_) {
-      throw new Error("Not supported")
+      throw new Error("Smart account signer doesn't need to sign transactions")
     }
   })
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `toSigner` functionality by integrating support for `EthersProvider`, updating the `Signer` type, and improving the test coverage for various signing scenarios using `viem` and `ethers`.

### Detailed summary
- Added tests for `toSigner` in `toSigner.test.ts`.
- Introduced `EthersProvider` type in `toSigner.ts`.
- Updated `toSigner` function to handle `EthersProvider`.
- Refined error handling for missing addresses.
- Modified `signTypedData` method to use `EthersProvider`.
- Removed the `MinimalSigner` type and related comments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->