### PR TITLE
chore: release 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/sdk
 
+## 0.0.11
+
+### Patch Changes
+
+- Fix WalletClient signer
+
 ## 0.0.10
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": "Biconomy",
   "repository": "github:bcnmy/sdk",
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `@biconomy/sdk` package from `0.0.10` to `0.0.11`, reflecting a patch change that includes a fix for the `WalletClient` signer. Additionally, it updates the `CHANGELOG.md` to document this change.

### Detailed summary
- Updated `CHANGELOG.md` to include version `0.0.11` and note the fix for `WalletClient` signer.
- Changed `version` in `package.json` from `0.0.10` to `0.0.11`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->