### PR TITLE
chore: fix getAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/sdk
 
+## 0.0.13
+
+### Patch Changes
+
+- Fix getAddress()
+
 ## 0.0.12
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/sdk",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": "Biconomy",
   "repository": "github:bcnmy/sdk",
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `@biconomy/sdk` package and improves the `getAddress()` function in the `src/sdk/account/toNexusAccount.ts` file to enhance error handling and address retrieval logic.

### Detailed summary
- Updated version in `package.json` from `0.0.12` to `0.0.13`.
- Modified the `getInitCode` function description to clarify its purpose.
- Enhanced error handling in `getAddress()`:
  - Introduced `accountAddressFromError` for better clarity.
  - Added logic to retrieve the address from the factory contract using `computeAccountAddress`.
  - Included a check to ensure the retrieved address is not a zero address before returning it.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->