### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/sdk
 
+## 0.0.14
+
+### Patch Changes
+
+- Add rhintestones attestation address during createAccount
+
 ## 0.0.13
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/sdk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "author": "Biconomy",
   "repository": "github:bcnmy/sdk",
   "main": "./dist/_cjs/index.js",

--- a/src/sdk/clients/createNexusSessionClient.test.ts
+++ b/src/sdk/clients/createNexusSessionClient.test.ts
@@ -150,7 +150,8 @@ describe("nexus.session.client", async () => {
       sessionPublicKey,
       description: `Session to increment a counter for ${testAddresses.Counter}`,
       moduleData: {
-        ...createSessionsResponse,
+        permissionIds: createSessionsResponse.permissionIds,
+        action: createSessionsResponse.action,
         mode: SmartSessionMode.USE
       }
     }

--- a/src/sdk/modules/smartSessionsValidator/toSmartSessionsValidator.dx.test.ts
+++ b/src/sdk/modules/smartSessionsValidator/toSmartSessionsValidator.dx.test.ts
@@ -149,7 +149,8 @@ describe("modules.smartSessions.dx", async () => {
       sessionPublicKey,
       description: `Session to increment a counter for ${testAddresses.Counter}`,
       moduleData: {
-        ...createSessionsResponse,
+        permissionIds: createSessionsResponse.permissionIds,
+        action: createSessionsResponse.action,
         mode: SmartSessionMode.USE
       }
     }

--- a/src/sdk/modules/smartSessionsValidator/toSmartSessionsValidator.sudo.policy.test.ts
+++ b/src/sdk/modules/smartSessionsValidator/toSmartSessionsValidator.sudo.policy.test.ts
@@ -132,7 +132,8 @@ describe("modules.smartSessions.sudo.policy", async () => {
       sessionPublicKey,
       description: `Session to increment a counter for ${testAddresses.Counter}`,
       moduleData: {
-        ...createSessionsResponse,
+        permissionIds: createSessionsResponse.permissionIds,
+        action: createSessionsResponse.action,
         mode: SmartSessionMode.USE
       }
     }

--- a/src/sdk/modules/smartSessionsValidator/toSmartSessionsValidator.test.ts
+++ b/src/sdk/modules/smartSessionsValidator/toSmartSessionsValidator.test.ts
@@ -256,7 +256,8 @@ describe("modules.smartSessions", async () => {
       description: `Session to increment a counter for ${testAddresses.Counter}`,
       sessionPublicKey,
       moduleData: {
-        ...createSessionsResponse,
+        permissionIds: createSessionsResponse.permissionIds,
+        action: createSessionsResponse.action,
         mode: SmartSessionMode.USE
       }
     }

--- a/src/sdk/modules/smartSessionsValidator/toSmartSessionsValidator.uni.policy.test.ts
+++ b/src/sdk/modules/smartSessionsValidator/toSmartSessionsValidator.uni.policy.test.ts
@@ -232,7 +232,8 @@ describe("modules.smartSessions.uni.policy", async () => {
       description: `Session to add balance to MockCallee for ${testAddresses.MockCallee}`,
       sessionPublicKey,
       moduleData: {
-        ...createSessionsResponse,
+        permissionIds: createSessionsResponse.permissionIds,
+        action: createSessionsResponse.action,
         mode: SmartSessionMode.USE
       }
     }

--- a/src/test/playground.test.ts
+++ b/src/test/playground.test.ts
@@ -164,7 +164,8 @@ describe.skipIf(!playgroundTrue())("playground", () => {
     expect(balanceAfter - balanceBefore).toBe(1n)
   })
 
-  test("should test creating and using a session", async () => {
+  // Skipped because on base sepolia the attestations for smart sessions have not been created yet
+  test.skip("should test creating and using a session", async () => {
     const sessionsModule = toSmartSessionsValidator({
       account: nexusClient.account,
       signer: eoaAccount


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `@biconomy/sdk` package and includes changes to the handling of `createSessionsResponse` in several test files. It also adds a new entry to the `CHANGELOG.md` for version `0.0.14`, indicating the addition of the `rhintestones` attestation address.

### Detailed summary
- Updated version in `package.json` from `0.0.13` to `0.0.14`.
- Added entry in `CHANGELOG.md` for version `0.0.14`:
  - Added `rhintestones` attestation address during `createAccount`.
- Modified multiple test files to replace `...createSessionsResponse` with:
  - `permissionIds: createSessionsResponse.permissionIds`
  - `action: createSessionsResponse.action`
  - `mode: SmartSessionMode.USE`
- Marked a test in `src/test/playground.test.ts` as skipped due to missing attestations on the base `sepolia`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->