### PR TITLE
chore: fix window.ethereum

### DIFF
--- a/src/sdk/account/utils/toSigner.ts
+++ b/src/sdk/account/utils/toSigner.ts
@@ -112,8 +112,15 @@ export async function toSigner<
     walletClient = signer as WalletClient<Transport, Chain | undefined, Account>
   }
 
+  const addressFromWalletClient =
+    walletClient?.account?.address ?? (await walletClient?.getAddresses())?.[0]
+
+  if (!addressFromWalletClient) {
+    throw new Error("address not found in wallet client")
+  }
+
   return toAccount({
-    address: walletClient.account.address,
+    address: addressFromWalletClient,
     async signMessage({ message }) {
       return walletClient.signMessage({ message })
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the method of retrieving the address from the `walletClient` in the `toSigner.ts` file. It adds error handling to ensure that an address is found before proceeding.

### Detailed summary
- Introduced `addressFromWalletClient` to fetch the address from `walletClient`.
- Added a check to throw an error if `addressFromWalletClient` is not found.
- Updated the return statement to use `addressFromWalletClient` instead of the previous direct access.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->