### PR TITLE
chore: addresses check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/sdk
 
+## 0.0.23
+
+### Patch Changes
+
+- Remove isTesting helper from testing framework
+
 ## 0.0.22
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/sdk",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "author": "Biconomy",
   "repository": "github:bcnmy/sdk",
   "main": "./dist/_cjs/index.js",

--- a/scripts/send:userOp.ts
+++ b/scripts/send:userOp.ts
@@ -5,7 +5,7 @@ import { privateKeyToAccount } from "viem/accounts"
 import { toNexusAccount } from "../src/sdk/account/toNexusAccount"
 import { getChain } from "../src/sdk/account/utils/getChain"
 import { createBicoBundlerClient } from "../src/sdk/clients/createBicoBundlerClient"
-import { biconomyPaymasterContext } from "../src/sdk/clients/createBicoPaymasterClient"
+import { biconomySponsoredPaymasterContext } from "../src/sdk/clients/createBicoPaymasterClient"
 
 config()
 
@@ -60,7 +60,7 @@ const main = async () => {
           paymaster: createPaymasterClient({
             transport: http(paymasterUrl)
           }),
-          paymasterContext: biconomyPaymasterContext
+          paymasterContext: biconomySponsoredPaymasterContext
         }
       : undefined),
     userOperation: {

--- a/src/sdk/account/toNexusAccount.addresses.test.ts
+++ b/src/sdk/account/toNexusAccount.addresses.test.ts
@@ -16,9 +16,12 @@ import {
   toTestClient
 } from "../../test/testUtils"
 import type { MasterClient, NetworkConfig } from "../../test/testUtils"
+import {
+  type NexusClient,
+  createSmartAccountClient
+} from "../clients/createSmartAccountClient"
 import type { NexusAccount } from "./toNexusAccount"
 import { getCounterFactualAddress } from "./utils"
-import { createSmartAccountClient } from "../clients/createSmartAccountClient"
 
 describe("nexus.account.addresses", async () => {
   let network: NetworkConfig

--- a/src/sdk/account/toNexusAccount.addresses.test.ts
+++ b/src/sdk/account/toNexusAccount.addresses.test.ts
@@ -1,0 +1,111 @@
+import {
+  http,
+  type Address,
+  type Chain,
+  type LocalAccount,
+  type PublicClient,
+  type WalletClient,
+  createWalletClient
+} from "viem"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { toNetwork } from "../../test/testSetup"
+import {
+  fundAndDeployClients,
+  getTestAccount,
+  killNetwork,
+  toTestClient
+} from "../../test/testUtils"
+import type { MasterClient, NetworkConfig } from "../../test/testUtils"
+import type { NexusAccount } from "./toNexusAccount"
+import { getCounterFactualAddress } from "./utils"
+import { createSmartAccountClient } from "../clients/createSmartAccountClient"
+
+describe("nexus.account.addresses", async () => {
+  let network: NetworkConfig
+  let chain: Chain
+  let bundlerUrl: string
+
+  // Test utils
+  let testClient: MasterClient
+  let eoaAccount: LocalAccount
+  let userTwo: LocalAccount
+  let nexusAccountAddress: Address
+  let nexusClient: NexusClient
+  let nexusAccount: NexusAccount
+  let walletClient: WalletClient
+
+  beforeAll(async () => {
+    network = await toNetwork()
+
+    chain = network.chain
+    bundlerUrl = network.bundlerUrl
+    eoaAccount = getTestAccount(0)
+    userTwo = getTestAccount(1)
+    testClient = toTestClient(chain, getTestAccount(5))
+
+    walletClient = createWalletClient({
+      account: eoaAccount,
+      chain,
+      transport: http()
+    })
+
+    nexusClient = await createSmartAccountClient({
+      signer: eoaAccount,
+      chain,
+      transport: http(),
+      bundlerTransport: http(bundlerUrl)
+    })
+
+    nexusAccount = nexusClient.account
+  })
+  afterAll(async () => {
+    await killNetwork([network?.rpcPort, network?.bundlerPort])
+  })
+
+  test("should check account address", async () => {
+    nexusAccountAddress = await nexusClient.account.getCounterFactualAddress()
+    const counterfactualAddressFromHelper = await getCounterFactualAddress(
+      testClient as unknown as PublicClient,
+      eoaAccount.address,
+      true
+    )
+    const gottenAddress = await nexusClient.account.getAddress()
+    expect(counterfactualAddressFromHelper).toBe(nexusAccountAddress)
+    expect(nexusAccount.address).toBe(nexusAccountAddress)
+    expect(nexusAccount.address).toBe(counterfactualAddressFromHelper)
+    expect(gottenAddress).toBe(nexusAccountAddress)
+  })
+
+  test("should check addresses after fund and deploy", async () => {
+    await fundAndDeployClients(testClient, [nexusClient])
+    const counterfactualAddressFromHelper = await getCounterFactualAddress(
+      testClient as unknown as PublicClient,
+      eoaAccount.address,
+      true
+    )
+    const gottenAddress = await nexusClient.account.getAddress()
+    expect(counterfactualAddressFromHelper).toBe(nexusAccountAddress)
+    expect(nexusAccount.address).toBe(nexusAccountAddress)
+    expect(nexusAccount.address).toBe(counterfactualAddressFromHelper)
+    expect(gottenAddress).toBe(nexusAccountAddress)
+  })
+
+  test("should override account address", async () => {
+    const someoneElsesNexusAddress =
+      "0xf0479e036343bC66dc49dd374aFAF98402D0Ae5f"
+    const newNexusClient = await createSmartAccountClient({
+      chain,
+      transport: http(),
+      bundlerTransport: http(bundlerUrl),
+      accountAddress: someoneElsesNexusAddress,
+      signer: eoaAccount
+    })
+    const accountAddress = await newNexusClient.account.getAddress()
+    const someoneElseCounterfactualAddress =
+      await newNexusClient.account.getCounterFactualAddress()
+    expect(newNexusClient.account.address).toBe(
+      someoneElseCounterfactualAddress
+    )
+    expect(accountAddress).toBe(someoneElsesNexusAddress)
+  })
+})

--- a/src/sdk/account/toNexusAccount.addresses.test.ts
+++ b/src/sdk/account/toNexusAccount.addresses.test.ts
@@ -20,6 +20,11 @@ import {
   type NexusClient,
   createSmartAccountClient
 } from "../clients/createSmartAccountClient"
+import {
+  RHINESTONE_ATTESTER_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
+} from "../constants"
 import type { NexusAccount } from "./toNexusAccount"
 import { getCounterFactualAddress } from "./utils"
 
@@ -56,7 +61,9 @@ describe("nexus.account.addresses", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     nexusAccount = nexusClient.account
@@ -70,7 +77,11 @@ describe("nexus.account.addresses", async () => {
     const counterfactualAddressFromHelper = await getCounterFactualAddress(
       testClient as unknown as PublicClient,
       eoaAccount.address,
-      true
+      true,
+      0n,
+      [RHINESTONE_ATTESTER_ADDRESS],
+      1,
+      TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     )
     const gottenAddress = await nexusClient.account.getAddress()
     expect(counterfactualAddressFromHelper).toBe(nexusAccountAddress)
@@ -84,7 +95,11 @@ describe("nexus.account.addresses", async () => {
     const counterfactualAddressFromHelper = await getCounterFactualAddress(
       testClient as unknown as PublicClient,
       eoaAccount.address,
-      true
+      true,
+      0n,
+      [RHINESTONE_ATTESTER_ADDRESS],
+      1,
+      TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     )
     const gottenAddress = await nexusClient.account.getAddress()
     expect(counterfactualAddressFromHelper).toBe(nexusAccountAddress)

--- a/src/sdk/account/toNexusAccount.test.ts
+++ b/src/sdk/account/toNexusAccount.test.ts
@@ -47,7 +47,8 @@ import {
 import {
   BICONOMY_ATTESTER_ADDRESS,
   MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS,
-  k1ValidatorAddress
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
 } from "../constants"
 import type { NexusAccount } from "./toNexusAccount"
 import {
@@ -95,7 +96,9 @@ describe("nexus.account", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     nexusAccount = nexusClient.account
@@ -345,7 +348,7 @@ describe("nexus.account", async () => {
 
     const finalSignature = encodePacked(
       ["address", "bytes"],
-      [k1ValidatorAddress, signatureData]
+      [TEST_ADDRESS_K1_VALIDATOR_ADDRESS, signatureData]
     )
 
     const contractResponse = await testClient.readContract({

--- a/src/sdk/account/toNexusAccount.test.ts
+++ b/src/sdk/account/toNexusAccount.test.ts
@@ -106,18 +106,6 @@ describe("nexus.account", async () => {
     await killNetwork([network?.rpcPort, network?.bundlerPort])
   })
 
-  test("should override account address", async () => {
-    const newNexusClient = await createSmartAccountClient({
-      chain,
-      transport: http(),
-      bundlerTransport: http(bundlerUrl),
-      accountAddress: "0xf0479e036343bC66dc49dd374aFAF98402D0Ae5f",
-      signer: eoaAccount
-    })
-    const accountAddress = await newNexusClient.account.getAddress()
-    expect(accountAddress).toBe("0xf0479e036343bC66dc49dd374aFAF98402D0Ae5f")
-  })
-
   test("should check isValidSignature PersonalSign is valid", async () => {
     const meta = await getAccountMeta(testClient, nexusAccountAddress)
 

--- a/src/sdk/account/toNexusAccount.ts
+++ b/src/sdk/account/toNexusAccount.ts
@@ -46,10 +46,10 @@ import {
 
 import {
   ENTRY_POINT_ADDRESS,
+  MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS,
+  MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS,
   MOCK_ATTESTER_ADDRESS,
-  RHINESTONE_ATTESTER_ADDRESS,
-  k1ValidatorAddress as k1ValidatorAddress_,
-  k1ValidatorFactoryAddress
+  RHINESTONE_ATTESTER_ADDRESS
 } from "../constants"
 // Constants
 import { EntrypointAbi } from "../constants/abi"
@@ -179,8 +179,8 @@ export const toNexusAccount = async (
     signer: _signer,
     index = 0n,
     module: module_,
-    factoryAddress = k1ValidatorFactoryAddress,
-    k1ValidatorAddress = k1ValidatorAddress_,
+    factoryAddress = MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS,
+    k1ValidatorAddress = MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS,
     key = "nexus account",
     name = "Nexus Account",
     attesters: attesters_ = [RHINESTONE_ATTESTER_ADDRESS],

--- a/src/sdk/account/utils/Utils.ts
+++ b/src/sdk/account/utils/Utils.ts
@@ -367,14 +367,6 @@ export const playgroundTrue = () => {
   }
 }
 
-export const isTesting = () => {
-  try {
-    return process?.env?.TEST === "true"
-  } catch (e) {
-    return false
-  }
-}
-
 type TenderlyDetails = {
   accountSlug: string
   projectSlug: string

--- a/src/sdk/account/utils/getCounterFactualAddress.ts
+++ b/src/sdk/account/utils/getCounterFactualAddress.ts
@@ -1,9 +1,9 @@
 import type { Address } from "viem"
 import type { PublicClient } from "viem"
 import {
+  MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS,
   MOCK_ATTESTER_ADDRESS,
-  RHINESTONE_ATTESTER_ADDRESS,
-  k1ValidatorFactoryAddress
+  RHINESTONE_ATTESTER_ADDRESS
 } from "../../constants"
 
 /**
@@ -30,7 +30,7 @@ export const getCounterFactualAddress = async (
   index = 0n,
   attesters = [RHINESTONE_ATTESTER_ADDRESS],
   threshold = 1,
-  factoryAddress = k1ValidatorFactoryAddress
+  factoryAddress = MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
 ) => {
   if (isTestnet) {
     attesters.push(MOCK_ATTESTER_ADDRESS)

--- a/src/sdk/clients/createBicoBundlerClient.test.ts
+++ b/src/sdk/clients/createBicoBundlerClient.test.ts
@@ -9,7 +9,11 @@ import {
 } from "../../test/testUtils"
 import type { MasterClient, NetworkConfig } from "../../test/testUtils"
 import { type NexusAccount, toNexusAccount } from "../account/toNexusAccount"
-import { ENTRY_POINT_ADDRESS } from "../constants"
+import {
+  ENTRY_POINT_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
+} from "../constants"
 import {
   type BicoBundlerClient,
   createBicoBundlerClient
@@ -38,7 +42,9 @@ describe("bico.bundler", async () => {
     nexusAccount = await toNexusAccount({
       signer: eoaAccount,
       chain,
-      transport: http()
+      transport: http(),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     bicoBundler = createBicoBundlerClient({ bundlerUrl, account: nexusAccount })

--- a/src/sdk/clients/createBicoPaymasterClient.test.ts
+++ b/src/sdk/clients/createBicoPaymasterClient.test.ts
@@ -11,9 +11,9 @@ import {
   parseUnits
 } from "viem"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
-import { paymasterTruthy, toNetworks } from "../../test/testSetup"
-import { getTestParamsForTestnet, killNetwork } from "../../test/testUtils"
-import type { NetworkConfig, TestnetParams } from "../../test/testUtils"
+import { toNetworks } from "../../test/testSetup"
+import { killNetwork } from "../../test/testUtils"
+import type { NetworkConfig } from "../../test/testUtils"
 import { type NexusAccount, toNexusAccount } from "../account/toNexusAccount"
 import {
   type BicoPaymasterClient,
@@ -28,8 +28,6 @@ import {
 describe.skip("bico.paymaster", async () => {
   // describe.runIf(paymasterTruthy())("bico.paymaster", async () => {
   let network: NetworkConfig
-  // Required for "TESTNET_FROM_ENV_VARS" networks
-  let testnetParams: TestnetParams
 
   let chain: Chain
   let bundlerUrl: string
@@ -71,8 +69,6 @@ describe.skip("bico.paymaster", async () => {
       transport: http()
     })
 
-    testnetParams = getTestParamsForTestnet(publicClient)
-
     paymaster = createBicoPaymasterClient({
       transport: http(paymasterUrl)
     })
@@ -80,8 +76,7 @@ describe.skip("bico.paymaster", async () => {
     nexusAccount = await toNexusAccount({
       signer: account,
       chain,
-      transport: http(),
-      ...testnetParams
+      transport: http()
     })
 
     nexusAccountAddress = await nexusAccount.getCounterFactualAddress()
@@ -91,8 +86,7 @@ describe.skip("bico.paymaster", async () => {
       chain,
       transport: http(),
       bundlerTransport: http(bundlerUrl),
-      paymaster,
-      ...testnetParams
+      paymaster
     })
   })
   afterAll(async () => {
@@ -148,8 +142,7 @@ describe.skip("bico.paymaster", async () => {
       }),
       paymasterContext,
       transport: http(),
-      bundlerTransport: http(bundlerUrl),
-      ...testnetParams
+      bundlerTransport: http(bundlerUrl)
     })
 
     const initialBalance = await publicClient.getBalance({
@@ -191,8 +184,7 @@ describe.skip("bico.paymaster", async () => {
       }),
       paymasterContext,
       transport: http(),
-      bundlerTransport: http(bundlerUrl),
-      ...testnetParams
+      bundlerTransport: http(bundlerUrl)
     })
 
     const initialBalance = await publicClient.getBalance({
@@ -238,8 +230,7 @@ describe.skip("bico.paymaster", async () => {
       }),
       paymasterContext,
       transport: http(),
-      bundlerTransport: http(bundlerUrl),
-      ...testnetParams
+      bundlerTransport: http(bundlerUrl)
     })
 
     const usdcBalance = await publicClient.readContract({
@@ -308,8 +299,7 @@ describe.skip("bico.paymaster", async () => {
       }),
       paymasterContext,
       transport: http(),
-      bundlerTransport: http(bundlerUrl),
-      ...testnetParams
+      bundlerTransport: http(bundlerUrl)
     })
 
     const supportedTokens = await paymaster.getSupportedTokens(nexusClient)

--- a/src/sdk/clients/createBundlerClient.test.ts
+++ b/src/sdk/clients/createBundlerClient.test.ts
@@ -14,14 +14,14 @@ import { smartAccountActions } from "./decorators/smartAccount"
 const COMPETITORS = [
   {
     name: "Pimlico",
-    bundlerUrl: `https://api.pimlico.io/v2/84532/rpc?apikey=${process.env.PIMLICO_API_KEY}`
+    chain: baseSepolia,
+    bundlerUrl: `https://api.pimlico.io/v2/${baseSepolia.id}/rpc?apikey=${process.env.PIMLICO_API_KEY}`
   }
 ]
 
 describe.each(COMPETITORS)(
   "nexus.interoperability with $name",
-  async ({ bundlerUrl }) => {
-    const chain = baseSepolia
+  async ({ bundlerUrl, chain }) => {
     const account = privateKeyToAccount(`0x${process.env.PRIVATE_KEY as Hex}`)
 
     const publicClient = createPublicClient({
@@ -111,9 +111,8 @@ describe.each(COMPETITORS)(
         address: nexusAccountAddress
       })
 
-      // Check that the balance has decreased by more than 1n (value sent)
-      // because gas fees were paid
-      expect(finalBalance).toBeLessThan(initialBalance - 1n)
+      // Check that the balance has decreased
+      expect(finalBalance).toBeLessThan(initialBalance)
     })
   }
 )

--- a/src/sdk/clients/createSmartAccountClient.test.ts
+++ b/src/sdk/clients/createSmartAccountClient.test.ts
@@ -31,7 +31,10 @@ import {
   makeInstallDataAndHash
 } from "../account/utils/Utils"
 import { getChain } from "../account/utils/getChain"
-import { k1ValidatorAddress } from "../constants"
+import {
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
+} from "../constants"
 import {
   type NexusClient,
   createSmartAccountClient
@@ -69,7 +72,9 @@ describe("nexus.client", async () => {
       signer: account,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
     nexusAccountAddress = await nexusClient.account.getCounterFactualAddress()
   })
@@ -234,7 +239,7 @@ describe("nexus.client", async () => {
       nexusClient.isModuleInstalled({
         module: {
           type: "validator",
-          address: k1ValidatorAddress,
+          address: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
           initData: "0x"
         }
       }),
@@ -270,14 +275,18 @@ describe("nexus.client", async () => {
       signer: viemSigner,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     const ethersNexusClient = await createSmartAccountClient({
       signer: wallet as EthersWallet,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     const sig1 = await viemNexusClient.signMessage({ message: "123" })
@@ -292,7 +301,9 @@ describe("nexus.client", async () => {
       signer: ethersWallet as EthersWallet,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     const hash = await ethersNexusClient.sendUserOperation({

--- a/src/sdk/clients/createSmartAccountClient.ts
+++ b/src/sdk/clients/createSmartAccountClient.ts
@@ -28,8 +28,8 @@ import {
 import type { EthersWallet } from "../account/utils/Utils"
 import type { EthereumProvider } from "../account/utils/toSigner"
 import {
-  k1ValidatorAddress as k1ValidatorAddress_,
-  k1ValidatorFactoryAddress
+  MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS,
+  MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
 } from "../constants"
 import type {
   AnyData,
@@ -205,8 +205,8 @@ export async function createSmartAccountClient(
     key = "nexus client",
     name = "Nexus Client",
     module,
-    factoryAddress = k1ValidatorFactoryAddress,
-    k1ValidatorAddress = k1ValidatorAddress_,
+    factoryAddress = MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS,
+    k1ValidatorAddress = MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS,
     bundlerTransport,
     transport,
     accountAddress,

--- a/src/sdk/clients/decorators/bundler/getGasFeeValues.ts
+++ b/src/sdk/clients/decorators/bundler/getGasFeeValues.ts
@@ -1,5 +1,4 @@
 import type { Account, Chain, Client, Hex, Transport } from "viem"
-import { isTesting } from "../../../account/utils/Utils"
 
 export type BicoRpcSchema = [
   {
@@ -66,10 +65,14 @@ export const getGasFeeValues = async (
     BicoRpcSchema
   >
 ): Promise<GetGasFeeValuesReturnType> => {
+  const isABiconomyBundler = client.transport.url
+    .toLowerCase()
+    .includes("biconomy")
+
   const gasPrice = await client.request({
-    method: isTesting()
-      ? "pimlico_getUserOperationGasPrice"
-      : "biconomy_getGasFeeValues",
+    method: isABiconomyBundler
+      ? "biconomy_getGasFeeValues"
+      : "pimlico_getUserOperationGasPrice",
     params: []
   })
 

--- a/src/sdk/clients/decorators/erc7579/erc7579.decorators.test.ts
+++ b/src/sdk/clients/decorators/erc7579/erc7579.decorators.test.ts
@@ -17,7 +17,10 @@ import {
   killNetwork,
   toTestClient
 } from "../../../../test/testUtils"
-import { k1ValidatorAddress } from "../../../constants"
+import {
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
+} from "../../../constants"
 import {
   type NexusClient,
   createSmartAccountClient
@@ -50,7 +53,9 @@ describe("erc7579.decorators", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     nexusAccountAddress = await nexusClient.account.getCounterFactualAddress()
@@ -80,14 +85,14 @@ describe("erc7579.decorators", async () => {
       nexusClient.isModuleInstalled({
         module: {
           type: "validator",
-          address: k1ValidatorAddress,
+          address: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
           initData: "0x"
         }
       })
     ])
 
     expect(installedExecutors[0].length).toBeTypeOf("number")
-    expect(installedValidators[0]).toEqual([k1ValidatorAddress])
+    expect(installedValidators[0]).toEqual([TEST_ADDRESS_K1_VALIDATOR_ADDRESS])
     expect(isHex(activeHook)).toBe(true)
     expect(fallbackSelector.length).toBeTypeOf("number")
     expect(supportsValidator).toBe(true)

--- a/src/sdk/clients/decorators/smartAccount/account.decorators.test.ts
+++ b/src/sdk/clients/decorators/smartAccount/account.decorators.test.ts
@@ -13,6 +13,10 @@ import {
   toTestClient
 } from "../../../../test/testUtils"
 import {
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
+} from "../../../constants"
+import {
   type NexusClient,
   createSmartAccountClient
 } from "../../createSmartAccountClient"
@@ -44,7 +48,9 @@ describe("account.decorators", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
     nexusAccountAddress = await nexusClient.account.getCounterFactualAddress()
     await fundAndDeployClients(testClient, [nexusClient])

--- a/src/sdk/constants/index.ts
+++ b/src/sdk/constants/index.ts
@@ -6,7 +6,6 @@ import {
   getValueLimitPolicy
 } from "@rhinestone/module-sdk"
 import { type Hex, toBytes, toHex } from "viem"
-import { isTesting } from "../account"
 import { ParamCondition } from "../modules/smartSessionsValidator/Types"
 
 export * from "./abi"
@@ -22,20 +21,10 @@ export const TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS: Hex =
   "0x704C800D313c6B184228B5b733bBd6BC3EA9832c"
 export const TEST_ADDRESS_K1_VALIDATOR_ADDRESS: Hex =
   "0xCfa6175DDC2eF918e527b2972D9AB8B149f151b7"
-
 export const MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS: Hex =
   "0x00000024115AA990F0bAE0B6b0D5B8F68b684cd6"
 export const MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS: Hex =
   "0x0000002D6DB27c52E3C11c1Cf24072004AC75cBa"
-
-export const k1ValidatorFactoryAddress: Hex = isTesting()
-  ? TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
-  : MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
-
-export const k1ValidatorAddress: Hex = isTesting()
-  ? TEST_ADDRESS_K1_VALIDATOR_ADDRESS
-  : MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS
-
 export const BICONOMY_ATTESTER_ADDRESS: Hex =
   "0xDE8FD2dBcC0CA847d11599AF5964fe2AEa153699"
 

--- a/src/sdk/modules/k1Validator/toK1Validator.test.ts
+++ b/src/sdk/modules/k1Validator/toK1Validator.test.ts
@@ -20,7 +20,10 @@ import {
   type NexusClient,
   createSmartAccountClient
 } from "../../clients/createSmartAccountClient"
-import { k1ValidatorAddress } from "../../constants"
+import {
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
+} from "../../constants"
 import { toK1Validator } from "./toK1Validator"
 
 describe("modules.k1Validator", async () => {
@@ -51,7 +54,9 @@ describe("modules.k1Validator", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     nexusAccountAddress = await nexusClient.account.getCounterFactualAddress()
@@ -90,7 +95,8 @@ describe("modules.k1Validator", async () => {
   test("k1Validator properties", async () => {
     const k1Validator = toK1Validator({
       signer: nexusClient.account.signer,
-      accountAddress: nexusClient.account.address
+      accountAddress: nexusClient.account.address,
+      address: TEST_ADDRESS_K1_VALIDATOR_ADDRESS
     })
     expect(k1Validator.signMessage).toBeDefined()
     expect(k1Validator.signUserOpHash).toBeDefined()
@@ -105,7 +111,7 @@ describe("modules.k1Validator", async () => {
     const isInstalledBefore = await nexusClient.isModuleInstalled({
       module: {
         type: "validator",
-        address: k1ValidatorAddress,
+        address: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
         initData: encodePacked(["address"], [eoaAccount.address])
       }
     })
@@ -113,7 +119,7 @@ describe("modules.k1Validator", async () => {
     if (!isInstalledBefore) {
       const hash = await nexusClient.installModule({
         module: {
-          address: k1ValidatorAddress,
+          address: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
           type: "validator",
           initData: encodePacked(["address"], [eoaAccount.address])
         }
@@ -127,7 +133,7 @@ describe("modules.k1Validator", async () => {
 
       const hashUninstall = nexusClient.uninstallModule({
         module: {
-          address: k1ValidatorAddress,
+          address: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
           type: "validator",
           deInitData
         }
@@ -139,7 +145,7 @@ describe("modules.k1Validator", async () => {
 
       const hashUninstall = nexusClient.uninstallModule({
         module: {
-          address: k1ValidatorAddress,
+          address: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
           type: "validator",
           deInitData
         }

--- a/src/sdk/modules/k1Validator/toK1Validator.ts
+++ b/src/sdk/modules/k1Validator/toK1Validator.ts
@@ -4,7 +4,7 @@ import {
   type SignableMessage,
   encodePacked
 } from "viem"
-import { k1ValidatorAddress } from "../../constants"
+import { MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS } from "../../constants"
 import { sanitizeSignature } from "../utils/Helpers"
 import type { Module, ModuleMeta, ModuleParameters } from "../utils/Types"
 import { toModule } from "../utils/toModule"
@@ -20,7 +20,7 @@ export type K1ModuleGetInitDataArgs = {
 export const getK1ModuleInitData = (
   _: K1ModuleGetInitDataArgs
 ): ModuleMeta => ({
-  address: k1ValidatorAddress,
+  address: MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS,
   type: "validator",
   initData: "0x"
 })
@@ -62,7 +62,7 @@ export const toK1Validator = (parameters: ToK1ValidatorParameters): Module => {
     moduleInitData: moduleInitData_,
     deInitData = "0x",
     accountAddress,
-    address = k1ValidatorAddress
+    address = MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS
   } = parameters
 
   const initData = initData_ ?? getK1InitData(initArgs_)

--- a/src/sdk/modules/ownableValidator/decorators/ownables.decorators.test.ts
+++ b/src/sdk/modules/ownableValidator/decorators/ownables.decorators.test.ts
@@ -20,7 +20,11 @@ import {
   type NexusClient,
   createSmartAccountClient
 } from "../../../clients/createSmartAccountClient"
-import { OWNABLE_VALIDATOR_ADDRESS } from "../../../constants"
+import {
+  OWNABLE_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
+} from "../../../constants"
 import { toOwnableValidator } from "../toOwnableValidator"
 
 describe("modules.ownables.decorators", async () => {
@@ -54,7 +58,9 @@ describe("modules.ownables.decorators", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     nexusAccountAddress = await nexusClient.account.getCounterFactualAddress()

--- a/src/sdk/modules/ownableValidator/toOwnableValidator.dx.test.ts
+++ b/src/sdk/modules/ownableValidator/toOwnableValidator.dx.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../../../test/testUtils"
 import type { MasterClient, NetworkConfig } from "../../../test/testUtils"
 import { createSmartAccountClient } from "../../clients/createSmartAccountClient"
+import { TEST_ADDRESS_K1_VALIDATOR_ADDRESS } from "../../constants"
+import { TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS } from "../../constants"
 import { ownableActions } from "./decorators"
 import { toOwnableValidator } from "./toOwnableValidator"
 
@@ -63,7 +65,9 @@ describe("modules.ownableValidator.dx", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     // Fund the account and deploy the smart contract wallet

--- a/src/sdk/modules/ownableValidator/toOwnableValidator.executor.test.ts
+++ b/src/sdk/modules/ownableValidator/toOwnableValidator.executor.test.ts
@@ -28,6 +28,8 @@ import {
 } from "../../clients/createSmartAccountClient"
 import { moduleActivator } from "../../clients/decorators/erc7579/moduleActivator"
 import {
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS,
   getAddOwnableExecutorOwnerAction,
   getExecuteOnOwnedAccountAction
 } from "../../constants"
@@ -62,7 +64,9 @@ describe("modules.ownableExecutor", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     nexusAccountAddress = await nexusClient.account.getCounterFactualAddress()
@@ -70,7 +74,8 @@ describe("modules.ownableExecutor", async () => {
 
     const k1Module = toK1Validator({
       signer: eoaAccount,
-      accountAddress: nexusClient.account.address
+      accountAddress: nexusClient.account.address,
+      address: TEST_ADDRESS_K1_VALIDATOR_ADDRESS
     })
 
     nexusClient.extend(moduleActivator(k1Module))

--- a/src/sdk/modules/ownableValidator/toOwnableValidator.test.ts
+++ b/src/sdk/modules/ownableValidator/toOwnableValidator.test.ts
@@ -27,8 +27,9 @@ import {
 } from "../../clients/createSmartAccountClient"
 import { parseModuleTypeId } from "../../clients/decorators/erc7579/supportsModule"
 import {
-  getOwnableValidatorSignature,
-  k1ValidatorAddress
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS,
+  getOwnableValidatorSignature
 } from "../../constants"
 import type { Module } from "../utils/Types"
 import { type OwnableActions, ownableActions } from "./decorators"
@@ -67,7 +68,9 @@ describe("modules.ownables", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     await fundAndDeployClients(testClient, [nexusClient])
@@ -301,6 +304,8 @@ describe("modules.ownables", async () => {
     expect(userOpSuccess).toBe(true)
     const [installedValidatorsAfter] =
       await nexusClient.getInstalledValidators()
-    expect(installedValidatorsAfter).toEqual([k1ValidatorAddress])
+    expect(installedValidatorsAfter).toEqual([
+      TEST_ADDRESS_K1_VALIDATOR_ADDRESS
+    ])
   })
 })

--- a/src/sdk/modules/smartSessionsValidator/decorators/smartSessions.decorators.test.ts
+++ b/src/sdk/modules/smartSessionsValidator/decorators/smartSessions.decorators.test.ts
@@ -16,13 +16,16 @@ import {
   type NexusClient,
   createSmartAccountClient
 } from "../../../clients/createSmartAccountClient"
+import {
+  TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+  TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
+} from "../../../constants"
 import type { CreateSessionDataParams } from "../Types"
 import {
   type SmartSessionModule,
   toSmartSessionsValidator
 } from "../toSmartSessionsValidator"
 import { smartSessionCreateActions, smartSessionUseActions } from "./"
-import { preparePermission } from "./preparePermission"
 
 describe("modules.smartSessions.decorators", async () => {
   let network: NetworkConfig
@@ -53,7 +56,9 @@ describe("modules.smartSessions.decorators", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl)
+      bundlerTransport: http(bundlerUrl),
+      k1ValidatorAddress: TEST_ADDRESS_K1_VALIDATOR_ADDRESS,
+      factoryAddress: TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS
     })
 
     sessionRequestedInfo = [

--- a/src/sdk/modules/smartSessionsValidator/toSmartSessionValidator.enable.mode.test.ts
+++ b/src/sdk/modules/smartSessionsValidator/toSmartSessionValidator.enable.mode.test.ts
@@ -44,8 +44,6 @@ import { toSmartSessionsValidator } from "./toSmartSessionsValidator"
 
 describe("modules.smartSessions.enable.mode.dx", async () => {
   let network: NetworkConfig
-  // Required for "TESTNET_FROM_ENV_VARS" networks
-  let testnetParams: TestnetParams
 
   let chain: Chain
   let bundlerUrl: string
@@ -89,14 +87,11 @@ describe("modules.smartSessions.enable.mode.dx", async () => {
       transport: http()
     })
 
-    testnetParams = getTestParamsForTestnet(publicClient)
-
     nexusAccount = await toNexusAccount({
       index: 1n,
       signer: eoaAccount,
       chain,
-      transport: http(),
-      ...testnetParams
+      transport: http()
     })
 
     nexusAccountAddress = await nexusAccount.getCounterFactualAddress()
@@ -107,8 +102,7 @@ describe("modules.smartSessions.enable.mode.dx", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl),
-      ...testnetParams
+      bundlerTransport: http(bundlerUrl)
     })
   })
 
@@ -289,8 +283,7 @@ describe("modules.smartSessions.enable.mode.dx", async () => {
       signer: eoaAccount,
       chain,
       transport: http(),
-      bundlerTransport: http(bundlerUrl),
-      ...testnetParams
+      bundlerTransport: http(bundlerUrl)
     })
 
     // Create a new smart sessions module with the session key

--- a/src/test/playground.test.ts
+++ b/src/test/playground.test.ts
@@ -39,8 +39,6 @@ import {
 
 describe.skipIf(!playgroundTrue())("playground", () => {
   let network: NetworkConfig
-  // Required for "TESTNET_FROM_ENV_VARS" networks
-  let testParams: TestnetParams
   // Nexus Config
   let chain: Chain
   let bundlerUrl: string
@@ -74,8 +72,6 @@ describe.skipIf(!playgroundTrue())("playground", () => {
       chain,
       transport: http()
     })
-
-    testParams = getTestParamsForTestnet(publicClient)
   })
 
   test("should init the smart account", async () => {
@@ -88,8 +84,7 @@ describe.skipIf(!playgroundTrue())("playground", () => {
         ? createBicoPaymasterClient({
             transport: http(network.paymasterUrl)
           })
-        : undefined,
-      ...testParams
+        : undefined
     })
   })
 
@@ -243,8 +238,7 @@ describe.skipIf(!playgroundTrue())("playground", () => {
       accountAddress: nexusClient.account.address,
       signer: eoaAccount,
       transport: http(),
-      bundlerTransport: http(bundlerUrl),
-      ...testParams
+      bundlerTransport: http(bundlerUrl)
     })
 
     const usePermissionsModule = toSmartSessionsValidator({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `@biconomy/sdk` package from version `0.0.22` to `0.0.23`, removing the `isTesting` helper, and replacing certain addresses with their mainnet counterparts. It also includes various updates to tests and constants.

### Detailed summary
- Updated `CHANGELOG.md` for version `0.0.23`.
- Removed `isTesting` helper from `src/sdk/account/utils/Utils.ts`.
- Changed `version` in `package.json` to `0.0.23`.
- Replaced `k1ValidatorFactoryAddress` with `MAINNET_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS`.
- Replaced `k1ValidatorAddress` with `MAINNET_ADDRESS_K1_VALIDATOR_ADDRESS`.
- Updated test files to use `TEST_ADDRESS_K1_VALIDATOR_ADDRESS` and `TEST_ADDRESS_K1_VALIDATOR_FACTORY_ADDRESS`.
- Modified `getGasFeeValues` method to check for Biconomy bundler.
- Adjusted various imports and references across multiple test files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->